### PR TITLE
[MOSIP-43648] Configure graceful pod termination with lifecycle hooks and grace periods

### DIFF
--- a/helm/digitalcard/.gitignore
+++ b/helm/digitalcard/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 charts/
+Chart.lock

--- a/helm/digitalcard/templates/deployment.yaml
+++ b/helm/digitalcard/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 60 }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/helm/digitalcard/values.yaml
+++ b/helm/digitalcard/values.yaml
@@ -126,7 +126,7 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
-    cpu: 1000m
+    cpu: '1'
     memory: 3000Mi
   requests:
     cpu: 700m
@@ -216,7 +216,16 @@ podAnnotations: {}
 
 ## lifecycleHooks for the  container to automate configuration before or after startup.
 ##
-lifecycleHooks: {}
+lifecycleHooks:
+  preStop:
+    exec:
+      command:
+        - sh
+        - -c
+        - sleep 30
+
+## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+terminationGracePeriodSeconds: 60
 
 ## Custom Liveness probes for
 ##
@@ -314,8 +323,8 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: "10"
+    repository: mosipid/os-shell
+    tag: "12-debian-12-r46"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION

    Chores
        Added 30s preStop hooks and set 60s termination grace periods to improve graceful shutdown across services.
        Adjusted container CPU/memory limits and Java heap settings per service for improved performance and stability.
        Updated ignore patterns to exclude chart lockfiles from version control.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pod termination behavior with graceful shutdown grace period configuration
  * Updated deployment resource limits and container image references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->