### PR TITLE
[MOSIP-43648] Configure graceful pod termination with lifecycle hooks and grace periods

### DIFF
--- a/helm/digitalcard/.gitignore
+++ b/helm/digitalcard/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 charts/
+Chart.lock

--- a/helm/digitalcard/templates/deployment.yaml
+++ b/helm/digitalcard/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 60 }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/helm/digitalcard/values.yaml
+++ b/helm/digitalcard/values.yaml
@@ -216,7 +216,16 @@ podAnnotations: {}
 
 ## lifecycleHooks for the  container to automate configuration before or after startup.
 ##
-lifecycleHooks: {}
+lifecycleHooks:
+  preStop:
+    exec:
+      command:
+        - sh
+        - -c
+        - sleep 30
+
+## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+terminationGracePeriodSeconds: 60
 
 ## Custom Liveness probes for
 ##
@@ -314,8 +323,8 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: "10"
+    repository: mosipid/os-shell
+    tag: "12-debian-12-r46"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
 		<dependency>
 			<groupId>io.mosip.kernel</groupId>
 			<artifactId>kernel-pdfgenerator</artifactId>
-			<version>1.3.0-java21-SNAPSHOT</version>
+			<version>1.3.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>io.mosip.kernel</groupId>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful pod shutdown with a configurable 60-second termination grace period and preStop lifecycle hook to ensure cleaner service termination during deployments.

* **Chores**
  * Updated container init image, adjusted image pull configuration, added lock file to ignore rules, and normalized a dependency version in the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->