### PR TITLE
find invalid char MOSIP-44427

### DIFF
--- a/find_invalid_xml_chars.py
+++ b/find_invalid_xml_chars.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+find_invalid_xml_chars.py
+
+Pinpoints which field(s) in a MOSIP credential / demographic-identity JSON
+contain characters that are ILLEGAL in XML 1.0. These are exactly the bytes
+that make openhtmltopdf fail in digital-card-service with:
+
+    SAXParseException: Character reference "&#xf" is an invalid XML character
+    -> KER-PDG-001 -> DCS-011 (card stuck at ISSUED)
+
+XML 1.0 allows only:  #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+Everything else (the C0 control chars 0x00-0x08, 0x0B, 0x0C, 0x0E-0x1F, etc.) is invalid.
+
+USAGE
+  # Scan the decrypted credential JSON that the service processes:
+  python find_invalid_xml_chars.py decrypted_credential.json
+
+  # Or pipe JSON in:
+  cat decrypted_credential.json | python find_invalid_xml_chars.py -
+
+The decrypted credential JSON is what you'd get from the datashare URL
+(datashareurl column) after decryption, i.e. the object PDFCardServiceImpl
+receives as `decryptedCredentialJson`.
+"""
+
+import json
+import sys
+
+
+def is_invalid_xml_char(cp: int) -> bool:
+    """Return True if a Unicode code point is NOT permitted in XML 1.0."""
+    if cp in (0x09, 0x0A, 0x0D):
+        return False
+    if 0x20 <= cp <= 0xD7FF:
+        return False
+    if 0xE000 <= cp <= 0xFFFD:
+        return False
+    if 0x10000 <= cp <= 0x10FFFF:
+        return False
+    return True
+
+
+def scan_string(path: str, value: str, findings: list):
+    bad = []
+    for idx, ch in enumerate(value):
+        cp = ord(ch)
+        if is_invalid_xml_char(cp):
+            bad.append((idx, cp))
+    if bad:
+        # Build a readable preview with offending chars shown as <0xNN>
+        preview_chars = []
+        for i, ch in enumerate(value[:120]):
+            cp = ord(ch)
+            preview_chars.append(f"<0x{cp:02X}>" if is_invalid_xml_char(cp) else ch)
+        findings.append({
+            "field": path,
+            "count": len(bad),
+            "codepoints": sorted({f"0x{cp:X}" for _, cp in bad}),
+            "first_positions": [i for i, _ in bad[:10]],
+            "preview": "".join(preview_chars),
+        })
+
+
+def walk(node, path, findings):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            walk(v, f"{path}.{k}" if path else str(k), findings)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            walk(v, f"{path}[{i}]", findings)
+    elif isinstance(node, str):
+        scan_string(path, node, findings)
+    # numbers / bools / null can't carry control chars
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(__doc__)
+        sys.exit(1)
+
+    src = sys.argv[1]
+    raw = sys.stdin.read() if src == "-" else open(src, "r", encoding="utf-8", errors="surrogatepass").read()
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        # If JSON itself won't parse, scan the raw text so we still locate the bytes.
+        print(f"[warn] JSON did not parse ({e}); scanning raw text instead.\n")
+        findings = []
+        scan_string("<raw-text>", raw, findings)
+        report(findings)
+        return
+
+    findings = []
+    walk(data, "", findings)
+    report(findings)
+
+
+def report(findings):
+    if not findings:
+        print("No invalid XML 1.0 characters found. This data would NOT trigger KER-PDG-001.")
+        return
+    print(f"Found {len(findings)} field(s) with invalid XML characters:\n")
+    for f in sorted(findings, key=lambda x: -x["count"]):
+        print(f"  FIELD     : {f['field']}")
+        print(f"  bad chars : {f['count']}  codepoints={f['codepoints']}")
+        print(f"  positions : {f['first_positions']}")
+        print(f"  preview   : {f['preview']}")
+        print()
+    print("=> These field values must be sanitized before the template merge / PDF render.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main/java/io/mosip/digitalcard/service/impl/PDFCardServiceImpl.java
+++ b/src/main/java/io/mosip/digitalcard/service/impl/PDFCardServiceImpl.java
@@ -168,6 +168,7 @@ public class PDFCardServiceImpl implements CardGeneratorService {
 			}
 			if (credentialType.equalsIgnoreCase("qrcode")) {
 				boolean isQRcodeSet = setQrCode(decryptedCredentialJson.toString(), attributes,isPhotoSet);
+				logInvalidXmlAttributes(attributes); // DEBUG: pinpoint attribute carrying XML-illegal chars
 				InputStream uinArtifact = templateGenerator.getTemplate(templateTypeCode, attributes, templateLang);
 				pdfbytes = generateUinCard(uinArtifact, password);
 			} else {
@@ -184,6 +185,7 @@ public class PDFCardServiceImpl implements CardGeneratorService {
 					logger.debug(DigitalCardServiceErrorCodes.QRCODE_NOT_SET.name());
 				}
 				// getting template and placing original valuespng
+				logInvalidXmlAttributes(attributes); // DEBUG: pinpoint attribute carrying XML-illegal chars
 				InputStream uinArtifact = templateGenerator.getTemplate(templateTypeCode, attributes, templateLang);
 				if (uinArtifact == null) {
 					logger.error(DigitalCardServiceErrorCodes.TEM_PROCESSING_FAILURE.name());
@@ -338,8 +340,17 @@ public class PDFCardServiceImpl implements CardGeneratorService {
 		logger.debug("UinCardGeneratorImpl::generateUinCard()::entry");
 		byte[] pdfSignatured=null;
 		ByteArrayOutputStream out = null;
+		// DEBUG: buffer the merged template so the offending markup can be dumped on failure
+		byte[] mergedTemplate = null;
 		try {
-			out = (ByteArrayOutputStream) pdfGenerator.generate(in);
+			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			byte[] tmp = new byte[8192];
+			int read;
+			while ((read = in.read(tmp)) != -1) {
+				buffer.write(tmp, 0, read);
+			}
+			mergedTemplate = buffer.toByteArray();
+			out = (ByteArrayOutputStream) pdfGenerator.generate(new ByteArrayInputStream(mergedTemplate));
 			PDFSignatureRequestDto request = new PDFSignatureRequestDto(lowerLeftX, lowerLeftY, upperRightX,
 					upperRightY, reason, 1, password);
 			request.setApplicationId("KERNEL");
@@ -372,12 +383,130 @@ public class PDFCardServiceImpl implements CardGeneratorService {
 
 		} catch (Exception e) {
 			logger.info("ERROR[] :{}",e);
+			dumpMergedTemplateOnFailure(mergedTemplate, e); // DEBUG: show offending markup/line
 			logger.error(PDFGeneratorExceptionCodeConstant.PDF_EXCEPTION.getErrorMessage(),e.getMessage()
 					+ ExceptionUtils.getStackTrace(e));
 		}
 		logger.debug("UinCardGeneratorImpl::generateUinCard()::exit");
 
 		return pdfSignatured;
+	}
+
+	/**
+	 * DEBUG INSTRUMENTATION
+	 * XML 1.0 permits only: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF].
+	 * Any other code point (the C0 control chars 0x00-0x08, 0x0B, 0x0C, 0x0E-0x1F, etc.) makes
+	 * openhtmltopdf fail with "Character reference &#xNN; is an invalid XML character"
+	 * -> KER-PDG-001 -> DCS-011, leaving the credential stuck at ISSUED.
+	 */
+	static boolean isInvalidXmlChar(int cp) {
+		if (cp == 0x9 || cp == 0xA || cp == 0xD) return false;
+		if (cp >= 0x20 && cp <= 0xD7FF) return false;
+		if (cp >= 0xE000 && cp <= 0xFFFD) return false;
+		if (cp >= 0x10000 && cp <= 0x10FFFF) return false;
+		return true;
+	}
+
+	/** Render a string with any XML-illegal chars shown as <0xNN> (capped for log size). */
+	static String markInvalid(String s) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < s.length() && sb.length() < 400; i++) {
+			int cp = s.charAt(i);
+			sb.append(isInvalidXmlChar(cp) ? String.format("<0x%02X>", cp) : String.valueOf((char) cp));
+		}
+		return sb.toString();
+	}
+
+	static boolean containsInvalidXml(String s) {
+		for (int i = 0; i < s.length(); i++) {
+			if (isInvalidXmlChar(s.charAt(i))) return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Logs every attribute whose value contains XML-illegal characters, with the key,
+	 * count, the offending code points, and a marked preview. This identifies the exact
+	 * field that breaks PDF generation.
+	 */
+	private void logInvalidXmlAttributes(Map<String, Object> attributes) {
+		try {
+			boolean anyBad = false;
+			for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+				Object val = entry.getValue();
+				if (!(val instanceof String)) {
+					continue;
+				}
+				String s = (String) val;
+				StringBuilder codepoints = new StringBuilder();
+				int badCount = 0;
+				for (int i = 0; i < s.length(); i++) {
+					int cp = s.charAt(i);
+					if (isInvalidXmlChar(cp)) {
+						badCount++;
+						if (codepoints.indexOf(String.format("0x%X", cp)) < 0) {
+							codepoints.append(String.format("0x%X ", cp));
+						}
+					}
+				}
+				if (badCount > 0) {
+					anyBad = true;
+					logger.error("INVALID-XML-ATTRIBUTE >> key='{}' badChars={} codepoints=[{}] preview='{}'",
+							entry.getKey(), badCount, codepoints.toString().trim(), markInvalid(s));
+				}
+			}
+			if (!anyBad) {
+				logger.info("INVALID-XML-ATTRIBUTE scan: no XML-illegal characters found in {} attributes",
+						attributes.size());
+			}
+		} catch (Exception ex) {
+			logger.warn("logInvalidXmlAttributes failed: {}", ex.getMessage());
+		}
+	}
+
+	/**
+	 * On PDF render failure, extracts the failing line number from the exception chain
+	 * (openhtmltopdf reports "lineNumber: N") and logs that line of the merged template
+	 * with XML-illegal characters marked. If no line number is present, logs every line
+	 * that contains illegal characters.
+	 */
+	private void dumpMergedTemplateOnFailure(byte[] mergedTemplate, Exception e) {
+		if (mergedTemplate == null) {
+			return;
+		}
+		try {
+			String html = new String(mergedTemplate, java.nio.charset.StandardCharsets.UTF_8);
+			String[] lines = html.split("\n", -1);
+
+			int failLine = -1;
+			Throwable t = e;
+			while (t != null) {
+				String msg = String.valueOf(t.getMessage());
+				java.util.regex.Matcher m = java.util.regex.Pattern.compile("lineNumber:\\s*(\\d+)").matcher(msg);
+				if (m.find()) {
+					failLine = Integer.parseInt(m.group(1));
+					break;
+				}
+				t = t.getCause();
+			}
+
+			if (failLine > 0 && failLine <= lines.length) {
+				int from = Math.max(0, failLine - 3);
+				int to = Math.min(lines.length, failLine + 2);
+				for (int i = from; i < to; i++) {
+					logger.error("MERGED-TEMPLATE L{}{} : {}", (i + 1),
+							(i + 1 == failLine ? " *FAIL*" : ""), markInvalid(lines[i]));
+				}
+			} else {
+				for (int i = 0; i < lines.length; i++) {
+					if (containsInvalidXml(lines[i])) {
+						logger.error("MERGED-TEMPLATE L{} (has XML-illegal chars): {}", (i + 1), markInvalid(lines[i]));
+					}
+				}
+			}
+		} catch (Exception ex) {
+			logger.warn("dumpMergedTemplateOnFailure failed: {}", ex.getMessage());
+		}
 	}
 }
 	


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a command-line utility to scan credential JSON files for characters that are invalid in XML, providing detailed reports on affected fields and invalid character counts.
  * Enhanced PDF card generation with improved error diagnostics, including XML character validation and detailed logging of problematic fields when generation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->